### PR TITLE
EXPLOIT fix - added hasBag to player compacting dop

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -242,7 +242,7 @@ local function RunWorkLoop()
 
                             if TruckDist < 2 then
                                 DrawText3D(Coords.x, Coords.y, Coords.z, "~g~E~w~ - Dispose of Garbage Bag")
-                                if IsControlJustPressed(0, 51) then
+                                if IsControlJustPressed(0, 51) and hasBag then
                                     QBCore.Functions.Progressbar("deliverbag", "Putting bag in trashmaster ..", 2000, false, true, {
                                         disableMovement = true,
                                         disableCarMovement = true,


### PR DESCRIPTION
Added "hasBag" check to the bag drop in the truck drop. Players were able to just stand there and hit G over and over till all bags at the stop were gone without going back to grab from the dumpster. 