### PR TITLE
Fixes truck boot closing at wrong time.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -128,7 +128,6 @@ local function DeliverAnim()
                     amountOfBags = newBagAmount
                     SetGarbageRoute()
                     QBCore.Functions.Notify(Lang:t("info.all_bags"))
-                    SetVehicleDoorShut(garbageVehicle, 5, false)
                 else
                     if hasMoreStops and nextStop == currentStop then
                         QBCore.Functions.Notify(Lang:t("info.depot_issue"))


### PR DESCRIPTION
WIth this line in here, the back door closes on first bag (or maybe first bin/route only) and then it never re-opens. Did about 10 runs with this commented out and seems to stay open now until all bags done, then it closes, then at next route it re-opens automatically.

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
